### PR TITLE
fix: uncontrolled, ',' tag query창에 남아있는 문제 해결

### DIFF
--- a/src/app/components/common/TagFilter.tsx
+++ b/src/app/components/common/TagFilter.tsx
@@ -6,17 +6,19 @@ import { useSearchParams, useRouter } from "next/navigation";
 const TagFilter = ({ tag }: { tag: string }) => {
   const searchParams = useSearchParams();
   const router = useRouter();
+  const tags = searchParams.get("tag")?.split(",").filter(Boolean) || [];
 
-  const checked = searchParams.get("tag")?.split(",").includes(tag);
+  const checked = tags.includes(tag);
 
   const onChange = () => {
-    const tags = searchParams.get("tag")?.split(",") || [];
     if (checked) {
       tags.splice(tags.indexOf(tag), 1);
     } else {
       tags.push(tag);
     }
-    router.push(`/tags?tag=${tags.join(",")}`);
+    const query = tags.length > 0 ? `?tag=${tags.join(",")}` : "";
+
+    router.push(`/tags${query}`);
   };
 
   return (


### PR DESCRIPTION
## 변경사항

### 시도
```typescript
const checked = searchParams.get("tag")?.split(",").includes(tag) || false; // false추가로 undefined가 되는 것을 막으려고 시도. 

결과: 에러는 사라졌지만, checkbox 체크, 해제 시 params에 ','가 생기는 버그가 생김
```

### 추적
```typescript
  tags = ["Frontend"]                                                                                         
  tags.splice(0, 1)  → []
  router.push(`/tags?tag=${"".join(",")}`)  → /tags?tag=                                                      
                  
  URL이 /tags?tag= (빈 문자열)

  그 다음에 다시 Frontend를 체크하면

  searchParams.get("tag")  // → "" (null이 아니라 빈 문자열)
  "".split(",")            // → [""]

  split은 빈 문자열에도 동작해서 [""]를 반환. 그래서 ["", "Frontend"] → ,Frontend가 됨
```

### 해결
```typescript
01. filter(Boolean)은 falsy한 값("", null, undefined, 0)을 전부 걸러냄

02. tags가 비었을 때 URL
  // tags가 [] 일 때
  `/tags?tag=${[].join(",")}` // → "/tags?tag="  ← 빈 파라미터가 남음

  이렇게 처리:

  const query = tags.length > 0 ? `?tag=${tags.join(",")}` : ""
  router.push(`/tags${query}`)

03. onChange가 실행되었을 때 업데이트 될 수 있게 query 선언 위치와 router push 위치를 if/else 가장 마지막으로 이동
```


## 관련이슈
#10 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 태그 필터링 로직을 개선하여 쿼리 매개변수 처리의 안정성을 향상했습니다.

* **개선 사항**
  * 태그 필터링 시 URL 네비게이션 동작을 최적화했습니다. 태그가 없을 때는 기본 경로로 이동하며, 태그가 있을 때만 쿼리 문자열을 포함합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->